### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/judge-env.yml
+++ b/.github/workflows/judge-env.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vmatrixdev/judge-env-aio
         tags: "latest"
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vmatrixdev/judge-env-cpp
         tags: "latest"

--- a/.github/workflows/pxc.yml
+++ b/.github/workflows/pxc.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Download proxysql-admin
       run: "wget https://raw.githubusercontent.com/percona/proxysql-admin-tool/v2.0/proxysql-admin && chmod 775 proxysql-admin"
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vmatrixdev/percona-xtradb-cluster-operator
         tags: "1.5.0-proxysql"

--- a/.github/workflows/tkestack-gpu-manager.yaml
+++ b/.github/workflows/tkestack-gpu-manager.yaml
@@ -20,7 +20,7 @@ jobs:
         tar czf "${ROOT}/go/build/gpu-manager-source.tar.gz" --transform 's,^,/gpu-manager-'${version}'/,' $(plugin::source_targets)
         cp -R "${ROOT}/build/"* "${ROOT}/go/build/"
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         version: "1.1.0"
         commit: "19a87c5b"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore